### PR TITLE
SHEET.GO: Fix small typo

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -296,7 +296,7 @@ func (f *File) GetSheetIndex(name string) int {
 //        fmt.Println(err)
 //        os.Exit(1)
 //    }
-//    for k, v := range xlsx.GetSheetMap()
+//    for k, v := range xlsx.GetSheetMap() {
 //        fmt.Println(k, v)
 //    }
 //


### PR DESCRIPTION
Adds a '{' to the example for sheet.GetSheetMap()

Signed-off-by: Mark Stenglein <mark@stengle.in>